### PR TITLE
SUBTE-184, fixed key and rana sended twice

### DIFF
--- a/CAF6000/boardcenter.cpp
+++ b/CAF6000/boardcenter.cpp
@@ -105,9 +105,7 @@ void BoardCenter::loadState(int state){
     m_brakesBypass->bypassBrakeReleased();
     m_tractionBypass->releaseBypass();
 
-    //Preguntar a Faba si sirve o vale apagar aca las lecturas de hardware (bypasses)
-    m_tractionBypass->offBypassHD();
-    qDebug()<< "Hardware OFF";
+
 
     if(state == APAGADO){
         lastState = APAGADO;
@@ -120,7 +118,7 @@ void BoardCenter::loadState(int state){
         ui->velocimetro->turnOn();
         ui->bypassFreno->turnOn();
         ui->bypassTraccion->turnOn();
-        m_tractionBypass->onBypassHD();
+
     }
 
     m_eventHandler->enableDiffusion();

--- a/CAF6000/boardhardware.cpp
+++ b/CAF6000/boardhardware.cpp
@@ -114,8 +114,6 @@ void BoardHardware::loadState(int state){
     else if(state == EN_MARCHA){
         lastState = EN_MARCHA;
         m_rana->setValue(1);
-        m_tractionLever->onTractionLever();
-        qDebug()<<"---- En Marcha ----";
     }
 
     m_eventHandler->enableDiffusion();

--- a/CAF6000/boardtop.cpp
+++ b/CAF6000/boardtop.cpp
@@ -80,16 +80,16 @@ void BoardTop::loadState(int state)
     if(state == APAGADO){
         lastState = APAGADO;
         m_connectors->setEstado(APAGADO);
-        m_keyTopBoard->keyOFF();
+        m_keyTopBoard->keyTurnOFF();
         m_topGauges->turnOffGauges();
-       // m_keyTopBoard->offKeyHD();
+
 
     } else if(state== EN_MARCHA){
         lastState = EN_MARCHA;
         m_connectors->setEstado(EN_MARCHA);
-        m_keyTopBoard->keyON();
+        m_keyTopBoard->keyTurnON();
         m_topGauges->turnOnGauges();
-        m_keyTopBoard->onKeyHD();
+
     }
     m_connectors->reset();
     m_eventHandler->enableDiffusion();

--- a/CAF6000/etc/control.ini
+++ b/CAF6000/etc/control.ini
@@ -1,6 +1,6 @@
-<!--    <serverIp>192.168.7.134</serverIp> CONFIGURACION INICIAL DE CONTROLES -->
+<!--    <serverIp>127.0.0.1</serverIp> CONFIGURACION INICIAL DE CONTROLES -->
 <ENET>
-   <serverIp>192.168.7.53</serverIp>
+   <serverIp>192.168.7.128</serverIp>
    <serverPort>5000</serverPort>
    <m_controlsHostName>c_simulador_1</m_controlsHostName>
    <m_visualHostName>v_simulador_1</m_visualHostName>

--- a/CAF6000/src/controllers/atp_controller.h
+++ b/CAF6000/src/controllers/atp_controller.h
@@ -95,6 +95,9 @@ private:
     double m_speedAllowed;
     double m_speedAllowedPrevious;
 
+    //State transition, true if ATP is on transition
+    bool m_transition;
+
     //Tasa desaceleracion
     double m_A1 = 0.7;
 

--- a/CAF6000/src/controllers/eventhandler.cpp
+++ b/CAF6000/src/controllers/eventhandler.cpp
@@ -156,9 +156,6 @@ void EventHandler::processValueChanged(std::string host, std::string key, std::s
             m_subte->reset();
             emit controlReset();
 
-            m_eNetClient->CambiarValorClave("c_rana",m_subte->rana());
-            m_eNetClient->CambiarValorClave("c_traccion",std::to_string((int)m_subte->traction()));
-            m_eNetClient->CambiarValorClave("c_freno_emergencia","des");
             m_eNetClient->CambiarValorClave("c_grifob138","con");
             m_eNetClient->CambiarValorClave("c_grifol2","con");
             m_eNetClient->CambiarValorClave("c_grifob73","con");
@@ -205,8 +202,6 @@ void EventHandler::processValueChanged(std::string host, std::string key, std::s
             m_eNetClient->CambiarValorClave("c_termico_33f1_6","con");
             m_eNetClient->CambiarValorClave("c_rana_6","0");
             m_eNetClient->CambiarValorClave("c_seta_emergencia_6","des");
-            m_eNetClient->CambiarValorClave("c_llave_atp","des");
-
 
             emit controlDisable();
             m_eNetClient->CambiarValorClave("c_listo","1");
@@ -263,7 +258,8 @@ void EventHandler::processValueChanged(std::string host, std::string key, std::s
             m_eNetClient->CambiarValorClave("c_termico_33f1_6","con");
             m_eNetClient->CambiarValorClave("c_rana_6","0");
             m_eNetClient->CambiarValorClave("c_seta_emergencia_6","des");
-            m_eNetClient->CambiarValorClave("c_llave_atp","des");
+
+            //m_eNetClient->Desconectar();
 
             Sleep(1000);
             emit closeApp();
@@ -279,12 +275,6 @@ void EventHandler::processValueChanged(std::string host, std::string key, std::s
 
             m_subte->reset();
             emit controlReset();
-
-            m_eNetClient->CambiarValorClave("c_rana",m_subte->rana());
-            m_eNetClient->CambiarValorClave("c_traccion",std::to_string((int)m_subte->traction()));
-            m_eNetClient->CambiarValorClave("c_freno_emergencia","des");
-            m_eNetClient->CambiarValorClave("c_llave_atp","des");
-
             emit controlDisable();
 
             m_eNetClient->CambiarValorClave("c_listo","1");

--- a/CAF6000/src/controllers/key_topboard_controller.cpp
+++ b/CAF6000/src/controllers/key_topboard_controller.cpp
@@ -63,6 +63,7 @@ void Key_TopBoard_Controller::processKeyTop(int k){
 
 void Key_TopBoard_Controller::onKeyHD(){
     if (m_tractionHardware->isHardwareEnable()){
+        m_tractionHardware->reset();
         m_checkJ->start();
         qDebug()<<"Hardware ON: LLave Hardware ON";
     }else{

--- a/CAF6000/src/controllers/tractionbypass_controller.cpp
+++ b/CAF6000/src/controllers/tractionbypass_controller.cpp
@@ -57,6 +57,7 @@ void TractionBypass_Controller::pressBypass()
 
 void TractionBypass_Controller::onBypassHD(){
     if (m_tractionHardware->isHardwareEnable()){
+        m_tractionHardware->reset();
         m_checkTB->start();
         qDebug()<<"Hardware ON: Bypass Traction";
     }else{

--- a/CAF6000/src/controllers/tractionlever_controller.cpp
+++ b/CAF6000/src/controllers/tractionlever_controller.cpp
@@ -7,15 +7,15 @@ TractionLever_Controller::TractionLever_Controller(SubteStatus * subte, Traction
     m_tractionHardware = th;
 
     m_checkJ = new QTimer();
-    m_checkJ->setInterval(100);
+    m_checkJ->setInterval(50);
 
     m_checkB = new QTimer();
-    m_checkB->setInterval(500);
+    m_checkB->setInterval(250);
 
     connect(m_checkJ,SIGNAL(timeout()),m_tractionHardware,SLOT(processValueChanged()));
-    connect(m_checkJ,SIGNAL(timeout()),m_tractionHardware,SLOT(processRanaChanged()));
-    connect(m_checkJ,SIGNAL(timeout()),m_tractionHardware,SLOT(processSetaChanged()));
-    connect(m_checkJ,SIGNAL(timeout()),m_tractionHardware,SLOT(processBottonChanged()));
+    connect(m_checkB,SIGNAL(timeout()),m_tractionHardware,SLOT(processRanaChanged()));
+    connect(m_checkB,SIGNAL(timeout()),m_tractionHardware,SLOT(processSetaChanged()));
+    connect(m_checkB,SIGNAL(timeout()),m_tractionHardware,SLOT(processBottonChanged()));
     connect(m_tractionHardware,SIGNAL(positionChanged(int)),this,SLOT(processValue(int)));
     connect(m_tractionLever,SIGNAL(positionChanged(int)),this,SLOT(processValue(int)));
 }
@@ -33,6 +33,7 @@ void TractionLever_Controller::setValue(int v)
 void TractionLever_Controller::onTractionLever(){
     bool check = m_tractionHardware->isHardwareEnable();
     if (check){
+        m_tractionHardware->reset();
         m_checkJ->start();
         m_checkB->start();
         qDebug()<<"Hardware ON: Palanca, HV, Seta, Rana";

--- a/CAF6000/src/models/subtestatus.cpp
+++ b/CAF6000/src/models/subtestatus.cpp
@@ -300,14 +300,14 @@ void SubteStatus::keyActivated(){
     m_keyATP = true;
     m_eventHandler->notifyValueChanged("c_llave_atp","con");
     emit atpOn();
-    qDebug() << "keyATP: " << m_keyATP;
+    qDebug() << "keyATP Model: " << m_keyATP;
 }
 
 void SubteStatus::keyDeactivated(){
     m_keyATP = false;
     m_eventHandler->notifyValueChanged("c_llave_atp","des");
     emit atpOff();
-    qDebug() << "keyATP: " << m_keyATP;
+    qDebug() << "keyATP Model: " << m_keyATP;
 }
 
 void SubteStatus::ranaAD(){

--- a/subtewidgets/tractionhardware.cpp
+++ b/subtewidgets/tractionhardware.cpp
@@ -51,7 +51,7 @@ TractionHardware::TractionHardware()
 void TractionHardware::processValueChanged(){
 
     getdata();
-    qDebug()<<"Valor: --->  "<< (this->axis.at(0));
+    //qDebug()<<"Valor Joystick: --->  "<< (this->axis.at(0));
     m_value = this->axis.at(0);
     bool m_auXdiedMan = this->buttons.at(0);
 
@@ -59,10 +59,10 @@ void TractionHardware::processValueChanged(){
         m_traction = 0;
     }else if (m_value < m_neutralTop){
         m_traction = static_cast<int>(((m_value-m_neutralTop)*100)/m_rangoT);
-        qDebug()<<"Valor TRACCION Emitido TH: --->  "<< m_traction;
+        //qDebug()<<"Valor TRACCION Joystick Emitido TH: --->  "<< m_traction;
     }else if (m_value > m_neutralLower){
         m_traction = -(static_cast<int>(((m_value-m_neutralLower)*100)/m_rangoB));
-        qDebug()<<"Valor BRAKE Emitido TH: --->  "<< m_traction;
+        //qDebug()<<"Valor BRAKE Joystick Emitido TH: --->  "<< m_traction;
     }
 
     emit positionChanged(m_traction);
@@ -91,10 +91,10 @@ void TractionHardware::processBottonChanged(){
 
         if (m_bypassBrake){
             emit brakeBypassPressed();
-            qDebug()<< "BOTON Bypass Freno presionado";
+            qDebug()<< "BOTON Joystick Bypass Freno presionado";
         }else{
             emit brakeBypassReleased();
-            qDebug()<< "BOTON Bypass Freno soltado";
+            qDebug()<< "BOTON Joystick Bypass Freno soltado";
         }
 
     }
@@ -105,10 +105,10 @@ void TractionHardware::processBottonChanged(){
 
         if (m_bypassTraction){
             emit tractionBypassPressed();
-            qDebug()<< "BOTON Bypass Traccion presionado";
+            qDebug()<< "BOTON Joystick Bypass Traccion presionado";
         }else{
             emit tractionBypassReleased();
-            qDebug()<< "BOTON Bypass Traccion soltado";
+            qDebug()<< "BOTON Joystick Bypass Traccion soltado";
         }
     }
 
@@ -129,6 +129,8 @@ void TractionHardware::processRanaChanged(){
 
         if (m_ranaAT) toEmit = -1;
         if (m_ranaAD) toEmit = 1;
+
+        qDebug() << "RANA Joystick: " << toEmit;
 
         emit ranaY(toEmit);
     }
@@ -162,10 +164,10 @@ void TractionHardware::processKeyTop(){
         m_keyTop = m_auXkeyTop;
         if (m_keyTop){
             emit processKeyTop(1);
-            qDebug()<< "SETA Joystick ON";
+            qDebug()<< "Key Joystick ON";
         }else{
             emit processKeyTop(0);
-            qDebug()<< "SETA Joystick OFF";
+            qDebug()<< "Key Joystick OFF";
         }
     }
 
@@ -207,7 +209,7 @@ bool TractionHardware::isHardwareEnable(){
 }
 
 
-/*
+
 void TractionHardware::reset(){
     getdata();
 
@@ -218,11 +220,12 @@ void TractionHardware::reset(){
     m_ranaAT = buttons.at(2);
     m_seta = buttons.at(3);
     m_keyTop = buttons.at(7);
+    qDebug()<< "Reset Hardware: "<< "diedMan: "<< m_diedMan << " bypassBrake: " << m_bypassBrake << " bypassTraction: " << m_bypassTraction << " ranaAD: "<< m_ranaAD << " ranaAT: " << m_ranaAT << " seta: " << m_seta << "keyTop" << m_keyTop;
 }
-*/
+
 
 void TractionHardware::onSound(int s){
-    qDebug()<< "<---- onSound ---->";
+    qDebug()<< "<---- onSound HARDWARE---->";
     switch(s){
     case 0:
         qDebug()<< "Playing SOUND Warning";

--- a/subtewidgets/tractionhardware.h
+++ b/subtewidgets/tractionhardware.h
@@ -39,7 +39,7 @@ public slots:
     void processSetaChanged();
     void processKeyTop();
     bool isHardwareEnable();
-    //void reset();
+    void reset();
     void onSound(int s);
 
 private:


### PR DESCRIPTION
Se juntaron dos TAREAS, SUBTE-184 y SUBTE-58.
SUBTE-58: 
Cuando entras en falla El ATP tiene dos estados posibles: en transición la objetivo va en 0 y la permitida en 15. No en transición -> arranca con los valores que tenia antes.
P.D.: se agrego comportamiento al ATP, solo se pudo probar en averia en la cual se lanza seta emergencia (aleatoria).

SUBTE-184:
probablemente sea PROBLEMA CON HARDWARE

P.D.: re agrego reset al HARDWARE. Se realiza un reset antes de prender cada TIMER asi el HARDWARE setea el estado inicial y solo envia cuando hay cambio.
